### PR TITLE
Chat-Spaceで自動更新機能を実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,9 @@
 $(function(){
+
     function buildHTML(message){
       if ( message.image ) {
         var html =
-        `<div class="chat-main__message-list__block">
+        `<div class="chat-main__message-list__block" data-message-id=${message.id}>
           <div class="chat-main__message-list__block__member">
             <div class="chat-main__message-list__block__member__name">
               ${message.user_name}
@@ -21,7 +22,7 @@ $(function(){
         return html;
       } else {
         var html =
-        `<div class="chat-main__message-list__block">
+        `<div class="chat-main__message-list__block" data-message-id=${message.id}>
           <div class="chat-main__message-list__block__member">
             <div class="chat-main__message-list__block__member__name">
               ${message.user_name}
@@ -56,7 +57,7 @@ $(function(){
         var html = buildHTML(data);
         $('.chat-main__message-list').append(html);
         $('form')[0].reset();
-        $('.chat-main__message-list').animate({ scrollTop: $('.chat-main__message-list')[0].scrollHeight});
+        $('.chat-main__message-list').animate({ scrollTop: $('.chat-main__message-list')[0] .scrollHeight});
       })
       .fail(function() {
         alert("メッセージ送信に失敗しました");
@@ -64,9 +65,35 @@ $(function(){
       .always(function(){
         $('.send-btn').prop('disabled', false);
       });
-  })
+  });
+
+  var reloadMessages = function() {
+    var last_message_id = $('.chat-main__message-list__block:last').data("message-id");
+    $.ajax({
+      url: 'api/messages',
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = "";
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.chat-main__message-list').append(insertHTML);
+        $('.chat-main__message-list').animate({ scrollTop: $('.chat-main__message-list')[0].scrollHeight});
+      }
+    })
+      .fail(function() {
+        alert('error');
+      });
+  };
+
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
+    
 });
-
-
 
 

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,9 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    
+    last_message_id = params[:id].to_i
+    
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.chat-main__message-list__block
+.chat-main__message-list__block{data: {message: {id: message.id}}}
   .chat-main__message-list__block__member
     .chat-main__message-list__block__member__name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
 json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
-json.image @message.image_url
+json.image @message.image.url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :users, only: [:edit, :update, :index]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    
     namespace :api do
       resources :messages, only: :index, defaults: { format: 'json' }
     end


### PR DESCRIPTION
# What
Chat-Spaceのチャットが自動で更新されるようにする実装

# Why
目指したいゴールは、Lineなどのチャットツールのように、相手からのメッセージが自動でブラウザに反映されること。
こうすることで、いちいちリロードしなくても相手からのメッセージが表示されるようになり、快適にチャットができるようにするため。

# 動画キャプチャ
https://gyazo.com/273f7f07cd1643b50977feef19d38486